### PR TITLE
fix: missing `firstPost` relation bricks frontend

### DIFF
--- a/js/src/forum/addLikeControls.js
+++ b/js/src/forum/addLikeControls.js
@@ -11,7 +11,7 @@ export default function addLikeControls() {
       if (currentRoute === 'index' || currentRoute === 'following') {
         const post = discussion.firstPost();
 
-        if (post.isHidden()) return;
+        if (!post || post.isHidden()) return;
 
         const likes = post.likes();
 


### PR DESCRIPTION
When the `firstPost` relation is missing from `discussion`, the relation function returns `false`. As a result, calls to `.isHidden()` fail and error, breaking the forum frontend.